### PR TITLE
Replace PyPy 3.10 manylinux with 3.11, add PyPy 3.11 to build matrices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         - '3.12'
         - '3.13'
         - 'pypy-3.10'
+        - 'pypy-3.11'
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
@@ -63,7 +64,7 @@ jobs:
         - cp311-cp311
         - cp312-cp312
         - cp313-cp313
-        - pp310-pypy310_pp73
+        - pp311-pypy311_pp73
     steps:
     - uses: actions/checkout@v6
     - run: /opt/python/${{ matrix.python-version }}/bin/python -m pip install setuptools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         - '3.12'
         - '3.13'
         - 'pypy-3.10'
+        - 'pypy-3.11'
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/test_arc4.py
+++ b/test_arc4.py
@@ -10,7 +10,6 @@ import unittest
 try:
     import setuptools # noqa
 except ImportError:
-    import sys
     import unittest.mock
     sys.modules['setuptools'] = unittest.mock.Mock()
 


### PR DESCRIPTION
## Summary

- The latest `quay.io/pypa/manylinux_2_28_x86_64` image no longer includes `pp310-pypy310_pp73`; confirmed by inspecting the container (`/opt/python/` only contains `pp311-pypy311_pp73`)
- Replace `pp310-pypy310_pp73` → `pp311-pypy311_pp73` in the manylinux build matrix
- Add `pypy-3.11` to `build-wheels` (macOS/Windows) and test matrices
- Keep `pypy-3.10` in `build-wheels` and test since it still works via `actions/setup-python` (PyPy 3.10 is not EOL)

Closes the remaining failure from #108 / #109.

## Test plan

- [ ] Confirm `build-manylinux-wheels (pp311-pypy311_pp73)` passes after merge
- [ ] Confirm `pypy-3.10` and `pypy-3.11` jobs pass in `build-wheels` and test matrices

🤖 Generated with [Claude Code](https://claude.com/claude-code)