### PR TITLE
Update macOS and Windows runner versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - macOS-12
-        - windows-2019
+        - macos-14
+        - windows-2022
         python-version:
         - '3.9'
         - '3.10'


### PR DESCRIPTION
## Summary

- `macOS-12` and `windows-2019` are no longer available on GitHub-hosted runners (confirmed: neither appears in [actions/runner-images](https://github.com/actions/runner-images/tree/main/images))
- All `build-wheels` jobs in the release workflow were stuck in `queued` state indefinitely as a result
- Replace with `macos-14` and `windows-2022`

## Test plan

- [ ] Confirm `build-wheels` jobs start and complete successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)